### PR TITLE
Contributor Model with Tests

### DIFF
--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -2,4 +2,5 @@ class Contributor < ApplicationRecord
   belongs_to :user
 
   validates :name, :user, presence: true
+  validates :name, uniqueness: true
 end


### PR DESCRIPTION
Adding a model for contributors. 
This model is intended to store the names of all those who had a role in writing / creating a book. 

E.g. a translated work might have 2 contributors : an author, and a translator. 

Contributors will be associated with books via the table contributions, which will hold records of the model contribution (this way a many-to-many relation can be reflected in the db)

We decided to put the attribute 'role' on contribution, instead of directly on the model contributor, as one contributor may have different roles in association with different books.