### PR TITLE
Remove column auth_token from users

### DIFF
--- a/db/migrate/20230225164640_remove_auth_token_from_users.rb
+++ b/db/migrate/20230225164640_remove_auth_token_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAuthTokenFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :auth_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_25_155355) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_25_164640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,9 +73,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_25_155355) do
     t.datetime "updated_at", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.string "auth_token"
     t.string "authentication_token"
-    t.index ["auth_token"], name: "index_users_on_auth_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Removing the auth_token column - unecessary due to presence of the authentication_token column